### PR TITLE
Changed IP address to the local loopback net block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Beware this project is still in development. There may be serious bugs or perfor
     await server.bind();
 
     // Connect to another peer
-    const peer = await server.connect('192.168.0.15', 12345);
+    const peer = await server.connect('127.0.0.1', 12345);
 
     // Send some raw data as a stream
     const data = Buffer.from("SomeGenericDataHere");


### PR DESCRIPTION
As the server/client is being setup within the same script, it might as well connect to '127.0.0.1' rather than require a user to specify the correct local IP address.